### PR TITLE
feat(user): add user entity, repository and migration

### DIFF
--- a/src/main/java/com/luciano/music_graph/model/Role.java
+++ b/src/main/java/com/luciano/music_graph/model/Role.java
@@ -1,0 +1,6 @@
+package com.luciano.music_graph.model;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/luciano/music_graph/model/User.java
+++ b/src/main/java/com/luciano/music_graph/model/User.java
@@ -1,0 +1,86 @@
+package com.luciano.music_graph.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.sql.Timestamp;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+@Table(name="users")
+@Entity
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class User implements UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @NotBlank
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @NotBlank
+    @Email
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @NotBlank
+    @Column(name = "password_hash")
+    private String password;
+
+    @NotNull
+    @Enumerated(value = EnumType.STRING)
+    private Role role;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private Timestamp createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(
+                new SimpleGrantedAuthority("ROLE_" + role.name())
+        );
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/src/main/java/com/luciano/music_graph/repository/UserRepository.java
+++ b/src/main/java/com/luciano/music_graph/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.luciano.music_graph.repository;
+
+import com.luciano.music_graph.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+}

--- a/src/main/resources/db/migration/V2__create_users.sql
+++ b/src/main/resources/db/migration/V2__create_users.sql
@@ -1,0 +1,10 @@
+create table users (
+   created_at timestamp(6),
+   updated_at timestamp(6),
+   id uuid not null,
+   email varchar(100) not null unique,
+   password_hash varchar(60) not null,
+   role varchar(40) check ((role in ('USER','ADMIN'))) not null,
+   username varchar(60) not null unique,
+   primary key (id)
+)


### PR DESCRIPTION
Closes #3

## What
Create User entity with its corresponding Flyway migration.

## Changes
- Add User JPA entity with fields: id, username, email, password_hash, created_at, updated_at
- Add UserRepository
- Create Flyway migration V2__create_users.sql