### PR TITLE
fix(user): replace Timestamp with Instant for date fields

### DIFF
--- a/src/main/java/com/luciano/music_graph/model/User.java
+++ b/src/main/java/com/luciano/music_graph/model/User.java
@@ -14,7 +14,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -51,11 +51,11 @@ public class User implements UserDetails {
 
     @CreationTimestamp
     @Column(name = "created_at")
-    private Timestamp createdAt;
+    private Instant createdAt;
 
     @UpdateTimestamp
     @Column(name = "updated_at")
-    private Timestamp updatedAt;
+    private Instant updatedAt;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {


### PR DESCRIPTION
## What
Replace `java.sql.Timestamp` with `java.time.Instant` for `created_at` and `updated_at` fields in `User` entity.

## Why
Instant is the modern and recommended type for UTC timestamps in Java, avoiding timezone issues associated with Timestamp.