### PR TITLE
feat(artist): add artist entity, tags, repositories and migration

### DIFF
--- a/src/main/java/com/luciano/music_graph/model/Artist.java
+++ b/src/main/java/com/luciano/music_graph/model/Artist.java
@@ -1,0 +1,45 @@
+package com.luciano.music_graph.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "artist")
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Artist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(unique = true, name = "mb_id")
+    private String mbId;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String country;
+
+    @Column(name = "debut_year")
+    private Integer debutYear;
+
+    private String type;
+
+    private String disambiguation;
+
+    @Column(name = "created_at")
+    @CreationTimestamp
+    private Instant createdAt;
+
+}

--- a/src/main/java/com/luciano/music_graph/model/Tags.java
+++ b/src/main/java/com/luciano/music_graph/model/Tags.java
@@ -1,0 +1,31 @@
+package com.luciano.music_graph.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "artist_tags")
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Tags {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    private Artist artist;
+
+    @Column(nullable = false)
+    private String tag;
+
+    private Integer count;
+}

--- a/src/main/resources/db/migration/V4__create_artists.sql
+++ b/src/main/resources/db/migration/V4__create_artists.sql
@@ -1,0 +1,20 @@
+create table artist(
+    id uuid not null,
+    mb_id varchar(124) not null,
+    name varchar(124) not null,
+    country varchar(124),
+    debut_year int,
+    type varchar (64),
+    disambiguation varchar(124),
+    created_at timestamp(6),
+    primary key (id)
+);
+
+create table artist_tags(
+    id uuid not null,
+    artist_id uuid not null,
+    tag varchar(64) not null,
+    count int,
+    primary key (id),
+    foreign key (artist_id) references artist(id)
+);


### PR DESCRIPTION
Closes #5

## What
Create the base `Artist` entity representing an artist imported from MusicBrainz.

## Changes
- Add Artist JPA entity with fields: `id`, `mbid`, `name`, `country`, `debut_year`, `type`, `disambiguation`, `created_at`
- Add ArtistTag JPA entity with fields: `id`, `artist_id`, `tag`, `count`
- Add `ArtistRepository` and `ArtistTagRepository`
- Create Flyway migration `V4__create_artists.sql`