### PR TITLE
feat(graph): add artist relation entities, repositories and migrations

### DIFF
--- a/src/main/java/com/luciano/music_graph/model/ApiArtistRelation.java
+++ b/src/main/java/com/luciano/music_graph/model/ApiArtistRelation.java
@@ -1,0 +1,18 @@
+package com.luciano.music_graph.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+
+@Entity
+@Table(name = "api_artist_relations")
+
+@Getter
+@Setter
+@NoArgsConstructor
+@SuperBuilder
+public class ApiArtistRelation extends ArtistRelationBase {
+}

--- a/src/main/java/com/luciano/music_graph/model/ArtistRelationBase.java
+++ b/src/main/java/com/luciano/music_graph/model/ArtistRelationBase.java
@@ -1,0 +1,38 @@
+package com.luciano.music_graph.model;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@MappedSuperclass
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+public abstract class ArtistRelationBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "artist_a_id")
+    private Artist artistA;
+
+    @ManyToOne
+    @JoinColumn(name = "artist_b_id")
+    private Artist artistB;
+
+    private Integer weight;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private Instant createdAt;
+}

--- a/src/main/java/com/luciano/music_graph/model/UserArtistRelation.java
+++ b/src/main/java/com/luciano/music_graph/model/UserArtistRelation.java
@@ -1,0 +1,26 @@
+package com.luciano.music_graph.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+
+@Entity
+@Table(name = "user_artist_relations")
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+public class UserArtistRelation extends ArtistRelationBase {
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+}

--- a/src/main/java/com/luciano/music_graph/repository/ApiArtistRelationRepository.java
+++ b/src/main/java/com/luciano/music_graph/repository/ApiArtistRelationRepository.java
@@ -1,0 +1,9 @@
+package com.luciano.music_graph.repository;
+
+import com.luciano.music_graph.model.ApiArtistRelation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ApiArtistRelationRepository extends JpaRepository<ApiArtistRelation, UUID> {
+}

--- a/src/main/java/com/luciano/music_graph/repository/UserArtistRelationRepository.java
+++ b/src/main/java/com/luciano/music_graph/repository/UserArtistRelationRepository.java
@@ -1,0 +1,9 @@
+package com.luciano.music_graph.repository;
+
+import com.luciano.music_graph.model.UserArtistRelation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserArtistRelationRepository extends JpaRepository<UserArtistRelation, UUID> {
+}

--- a/src/main/resources/db/migration/V6__create_api_artist_relations.sql
+++ b/src/main/resources/db/migration/V6__create_api_artist_relations.sql
@@ -1,0 +1,12 @@
+create table api_artist_relations(
+    id uuid not null,
+    artist_a_id uuid not null,
+    artist_b_id uuid not null,
+    weight int,
+    created_at timestamp(6),
+    primary key (id),
+    foreign key (artist_a_id) references artist(id),
+    foreign key (artist_b_id) references artist(id),
+    constraint chk_artist_order check ( artist_a_id < artist_b_id ),
+    constraint uq_api_artist_relation unique( artist_a_id, artist_b_id )
+);

--- a/src/main/resources/db/migration/V7__create_user_artist_relations.sql
+++ b/src/main/resources/db/migration/V7__create_user_artist_relations.sql
@@ -1,0 +1,14 @@
+create table user_artist_relations(
+    id uuid not null,
+    artist_a_id uuid not null,
+    artist_b_id uuid not null,
+    user_id uuid not null,
+    weight int,
+    created_at timestamp(6),
+    primary key (id),
+    foreign key (artist_a_id) references artist(id),
+    foreign key (artist_b_id) references artist(id),
+    foreign key (user_id) references users(id),
+    constraint chk_artist_order check ( artist_a_id < artist_b_id ),
+    constraint uq_user_artist_relation unique ( user_id, artist_a_id, artist_b_id )
+);


### PR DESCRIPTION
Closes #10

## What
Create the class hierarchy to represent relationships between artists, separating objective API-based relations from subjective user-defined ones.

## Changes
- Add `ArtistRelationBase` as `@MappedSuperclass` with fields: `id`, `artistA`, `artistB`, `weight`, `createdAt`
- Add `ApiArtistRelation` entity (global, populated from Last.fm match score)
- Add `UserArtistRelation` entity with additional `user_id` field (manual user relations)
- Add unique constraint `artistA_id < artistB_id` on both tables to avoid inverse duplicates
- Add `ApiArtistRelationRepository` and `UserArtistRelationRepository`
- Create Flyway migrations `V6__create_api_artist_relations.sql` and `V7__create_user_artist_relations.sql`