### PR TITLE
feat(config): add global exception handler with standard error format

### DIFF
--- a/src/main/java/com/luciano/music_graph/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/luciano/music_graph/config/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.luciano.music_graph.config;
+
+import com.luciano.music_graph.dto.ExceptionHandlerDto;
+import com.luciano.music_graph.exception.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private ResponseEntity<ExceptionHandlerDto> buildResponse(HttpStatus status, String message){
+        return ResponseEntity.status(status).body(new ExceptionHandlerDto(
+                status.value(),
+                status.getReasonPhrase(),
+                message,
+                Instant.now()
+        ));
+    }
+
+    @ExceptionHandler({ArtistNotFoundException.class, EmailNotFoundException.class, LastFmArtistNotFoundException.class,
+    RefreshTokenNotFoundException.class, UserArtistNotFoundException.class, UserNotFoundException.class})
+    public ResponseEntity<ExceptionHandlerDto> handleNotFound(RuntimeException ex) {
+        return buildResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler({LastFmApiException.class, UserAlreadyExistsException.class, UsernameAlreadyExistsException.class})
+    public ResponseEntity<ExceptionHandlerDto> handlerBadRequest(RuntimeException ex){
+        return buildResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(RefreshTokenExpirationException.class)
+    public ResponseEntity<ExceptionHandlerDto> refreshTokenExpiration(RefreshTokenExpirationException ex){
+        return buildResponse(HttpStatus.UNAUTHORIZED, ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionHandlerDto> genericHandler(Exception ex){
+        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+    }
+}

--- a/src/main/java/com/luciano/music_graph/config/JwtAuthFilter.java
+++ b/src/main/java/com/luciano/music_graph/config/JwtAuthFilter.java
@@ -1,9 +1,11 @@
 package com.luciano.music_graph.config;
 
+import com.luciano.music_graph.dto.ExceptionHandlerDto;
 import com.luciano.music_graph.model.User;
 import com.luciano.music_graph.repository.UserRepository;
 import com.luciano.music_graph.service.JwtService;
 import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.security.auth.message.AuthException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,8 +16,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -25,6 +29,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
     private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return request.getRequestURI().startsWith("/api/auth/");
+    }
+
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -33,7 +44,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String userId;
 
         if (authHeader == null || !authHeader.startsWith("Bearer ")){
-            filterChain.doFilter(request, response);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("application/json");
+            response.getWriter().write(objectMapper.writeValueAsString(
+                    new ExceptionHandlerDto(403, "Forbidden", "Access denied", Instant.now())
+            ));
             return;
         }
 
@@ -43,6 +58,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             userId = jwtService.extractUserId(jwt);
         } catch (ExpiredJwtException ex){
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write(objectMapper.writeValueAsString(
+                    new ExceptionHandlerDto(401, "Unauthorized", "Missing or invalid token", Instant.now())
+            ));
             return;
         }
 

--- a/src/main/java/com/luciano/music_graph/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/luciano/music_graph/config/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package com.luciano.music_graph.config;
+
+import com.luciano.music_graph.dto.ExceptionHandlerDto;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.getWriter().write(objectMapper.writeValueAsString(
+                new ExceptionHandlerDto(401, "Unauthorized", authException.getMessage(), Instant.now())
+        ));
+    }
+}

--- a/src/main/java/com/luciano/music_graph/dto/ExceptionHandlerDto.java
+++ b/src/main/java/com/luciano/music_graph/dto/ExceptionHandlerDto.java
@@ -1,0 +1,11 @@
+package com.luciano.music_graph.dto;
+
+import java.time.Instant;
+
+public record ExceptionHandlerDto(
+        int status,
+        String error,
+        String message,
+        Instant timestamp
+) {
+}


### PR DESCRIPTION
Closes #14

## What
Implement a global error handler for consistent error responses across the API.

## Changes
- Add `GlobalExceptionHandler` with `@RestControllerAdvice`
- Handle: `EntityNotFoundException` (404), `ValidationException` (400), auth errors (401), unexpected errors (500)
- Standard error format: `{ status, error, message, timestamp }`