### PR TITLE
feat(auth): Google OAuth2 login with JWT token emission

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,12 @@
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
+
+		<!--    OAuth    -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-client</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/luciano/music_graph/config/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/luciano/music_graph/config/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,66 @@
+package com.luciano.music_graph.config;
+
+import com.luciano.music_graph.model.RefreshToken;
+import com.luciano.music_graph.model.User;
+import com.luciano.music_graph.service.JwtService;
+import com.luciano.music_graph.service.RefreshTokenService;
+import com.luciano.music_graph.service.UserService;
+import com.luciano.music_graph.utils.CookieUtils;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtService jwtService;
+    private final RefreshTokenService refreshTokenService;
+    private final UserService userService;
+    private final CookieUtils cookieUtils;
+    private final ObjectMapper mapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        OAuth2AuthenticationToken oAuthToken = (OAuth2AuthenticationToken) authentication;
+
+        assert oAuth2User != null;
+        String email = oAuth2User.getAttribute("email");
+        String name = oAuth2User.getAttribute("name");
+        String registrationId = oAuthToken.getAuthorizedClientRegistrationId();
+
+        // busca o crea el usuario
+        User user = userService.findByIdOrCreate(email, name, registrationId);
+
+        // genera el access token
+        String accessToken = jwtService.generateToken(user);
+
+        // genera el refresh token
+        RefreshToken refreshToken = refreshTokenService.create(user.getId());
+
+        ResponseCookie cookie = cookieUtils.createRefreshTokenCookie(refreshToken.getToken());
+
+        // crea un mapper para no hacer json a mano
+        String json = mapper.writeValueAsString(
+                Map.of("accessToken", accessToken)
+        );
+
+        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        response.setContentType("application/json");
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/com/luciano/music_graph/config/PasswordConfig.java
+++ b/src/main/java/com/luciano/music_graph/config/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.luciano.music_graph.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/luciano/music_graph/config/SecurityConfig.java
+++ b/src/main/java/com/luciano/music_graph/config/SecurityConfig.java
@@ -3,9 +3,11 @@ package com.luciano.music_graph.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -17,6 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthFilter jwtAuthFilter;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http){
@@ -24,17 +27,17 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/auth/login/oauth2/**").permitAll()
                         .anyRequest().authenticated()
                 )
+                .oauth2Login(oauth -> oauth.successHandler(oAuth2AuthenticationSuccessHandler))
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 
-    @Bean
-    public PasswordEncoder passwordEncoder(){
-        return new BCryptPasswordEncoder();
-    }
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {

--- a/src/main/java/com/luciano/music_graph/model/AuthProvider.java
+++ b/src/main/java/com/luciano/music_graph/model/AuthProvider.java
@@ -1,0 +1,6 @@
+package com.luciano.music_graph.model;
+
+public enum AuthProvider {
+    LOCAL,
+    GOOGLE
+}

--- a/src/main/java/com/luciano/music_graph/model/User.java
+++ b/src/main/java/com/luciano/music_graph/model/User.java
@@ -41,13 +41,17 @@ public class User implements UserDetails {
     @Column(unique = true, nullable = false)
     private String email;
 
-    @NotBlank
     @Column(name = "password_hash")
     private String password;
 
     @NotNull
     @Enumerated(value = EnumType.STRING)
     private Role role;
+
+    @NotNull
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "auth_provider")
+    private AuthProvider provider;
 
     @CreationTimestamp
     @Column(name = "created_at")

--- a/src/main/java/com/luciano/music_graph/repository/UserRepository.java
+++ b/src/main/java/com/luciano/music_graph/repository/UserRepository.java
@@ -10,4 +10,5 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
     boolean existsByUsername(String username);
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/luciano/music_graph/service/AuthService.java
+++ b/src/main/java/com/luciano/music_graph/service/AuthService.java
@@ -3,6 +3,7 @@ package com.luciano.music_graph.service;
 import com.luciano.music_graph.dto.AuthTokens;
 import com.luciano.music_graph.dto.LoginRequest;
 import com.luciano.music_graph.dto.RegisterRequest;
+import com.luciano.music_graph.model.AuthProvider;
 import com.luciano.music_graph.model.RefreshToken;
 import com.luciano.music_graph.model.User;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +39,11 @@ public class AuthService {
                 )
         );
 
-        User user = userService.access(request);
+        User user = userService.getUserEntityByEmail(request.email());
+
+        if(user.getProvider() != AuthProvider.LOCAL) {
+            throw new RuntimeException("Use OAuth login for this account");
+        }
 
         RefreshToken refreshToken = refreshTokenService.create(user.getId());
 

--- a/src/main/java/com/luciano/music_graph/service/UserService.java
+++ b/src/main/java/com/luciano/music_graph/service/UserService.java
@@ -6,12 +6,15 @@ import com.luciano.music_graph.exception.EmailNotFoundException;
 import com.luciano.music_graph.exception.UserAlreadyExistsException;
 import com.luciano.music_graph.exception.UsernameAlreadyExistsException;
 import com.luciano.music_graph.mapper.UserMapper;
+import com.luciano.music_graph.model.AuthProvider;
 import com.luciano.music_graph.model.Role;
 import com.luciano.music_graph.model.User;
 import com.luciano.music_graph.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +32,7 @@ public class UserService {
         User user = mapper.toEntity(request);
         user.setPassword(passwordEncoder.encode(request.password()));
         user.setRole(Role.USER);
+        user.setProvider(AuthProvider.LOCAL);
 
         return userRepository.save(user);
     }
@@ -36,5 +40,47 @@ public class UserService {
     public User access(LoginRequest request){
 
         return userRepository.findByEmail(request.email()).orElseThrow(()-> new EmailNotFoundException(request.email()));
+    }
+
+    public User getUserEntityByEmail(String email){
+
+        return userRepository.findByEmail(email).orElseThrow(() -> new EmailNotFoundException(email));
+    }
+
+    private String generateUniqueUsername(String base) {
+        String username = base.replaceAll("\\s+", "").toLowerCase();
+        int counter = 0;
+
+        while (userRepository.findByUsername(username).isPresent()) {
+            counter++;
+            username = base + counter;
+        }
+
+        return username;
+    }
+
+    public User findByIdOrCreate(String email, String name, String providerStr){
+
+        AuthProvider provider = AuthProvider.valueOf(providerStr.toUpperCase());
+
+        Optional<User> existing = userRepository.findByEmail(email);
+
+        if(existing.isPresent()) {
+            User user = existing.get();
+
+            if(user.getProvider() != provider) {
+                throw new RuntimeException("Email already registered with different provider");
+            }
+
+            return user;
+        }
+
+        User u = new User();
+        u.setEmail(email);
+        u.setUsername(generateUniqueUsername(name));
+        u.setProvider(provider);
+        u.setRole(Role.USER);
+
+        return userRepository.save(u);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,16 @@
 spring:
   application:
     name: music_graph
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_ID}
+            client-secret: ${GOOGLE_SECRET}
+            scope:
+              - profile
+              - email
 
 lastfm:
   api-key: ${LAST_FM_API_KEY}

--- a/src/main/resources/db/migration/V13__add_provider_and_password_null_in_user.sql
+++ b/src/main/resources/db/migration/V13__add_provider_and_password_null_in_user.sql
@@ -1,0 +1,3 @@
+alter table users
+add column auth_provider varchar(60),
+alter column password_hash drop not null;


### PR DESCRIPTION
Closes #41

## What
Add Google OAuth2 authentication as an alternative to email/password login. JWT and refresh tokens are still used internally, OAuth2 is only the initial authentication mechanism.

## Changes
- Add `AuthProvider` enum and update User entity to support nullable password
- Create migration `V13__add_provider_and_password_null_in_users.sql`
- Add `PasswordConfig` and update `SecurityConfig` with OAuth2 client configuration
- Add `GOOGLE_ID` and `GOOGLE_SECRET` environment variables
- Add `OAuth2AuthenticationSuccessHandler`: intercepts Google callback and emits own JWT + refresh token
- Update `AuthService`, `UserService` and `UserRepository` to support OAuth2 user creation flow
- Update `pom.xml` with `spring-boot-starter-oauth2-client` dependency