### PR TITLE
refactor(userartist): source artists from user-artist service and enrich tag responses

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 services:
   db:
     image: postgres:16
-    container_name: music_graph_db
+#    container_name: music_graph_db
     restart: always
     environment:
       POSTGRES_DB: music_graph
@@ -20,7 +20,7 @@ services:
 
   app:
     build: .
-    container_name: music_graph
+#    container_name: music_graph
     restart: always
     depends_on:
       db:

--- a/src/main/java/com/luciano/music_graph/controller/ArtistController.java
+++ b/src/main/java/com/luciano/music_graph/controller/ArtistController.java
@@ -1,9 +1,9 @@
 package com.luciano.music_graph.controller;
 
-import com.luciano.music_graph.dto.ArtistDetail;
 import com.luciano.music_graph.dto.ArtistSearchResult;
+import com.luciano.music_graph.dto.UserArtistDetail;
 import com.luciano.music_graph.dto.UserArtistResponse;
-import com.luciano.music_graph.dto.userArtistTag.TagsByArtistResponse;
+import com.luciano.music_graph.dto.userTag.TagResponse;
 import com.luciano.music_graph.model.User;
 import com.luciano.music_graph.service.ArtistService;
 import com.luciano.music_graph.service.UserArtistService;
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,8 +30,8 @@ public class ArtistController {
     }
 
     @GetMapping("/{mbid}")
-    public ResponseEntity<ArtistDetail> getByMbid(@PathVariable String mbid){
-        return ResponseEntity.ok(artistService.getOrImport(mbid));
+    public ResponseEntity<UserArtistDetail> getByMbid(@AuthenticationPrincipal User user, @PathVariable String mbid){
+        return ResponseEntity.ok(userArtistService.getArtist(user, mbid));
     }
 
     @PostMapping("/{mbid}/follow")
@@ -51,8 +53,13 @@ public class ArtistController {
         return ResponseEntity.ok(userArtistService.getAllFollowed(user));
     }
 
+//    @GetMapping("/{mbid}/tags")
+//    public ResponseEntity<TagsByArtistResponse> getTagByArtist(@PathVariable String mbid){
+//        return ResponseEntity.ok(userArtistTagService.getTagsByArtistMbid(mbid));
+//    }
+
     @GetMapping("/{mbid}/tags")
-    public ResponseEntity<TagsByArtistResponse> getTagByArtist(@PathVariable String mbid){
-        return ResponseEntity.ok(userArtistTagService.getTagsByArtistMbid(mbid));
+    public ResponseEntity<List<TagResponse>> getTagByArtist(@AuthenticationPrincipal User user, @PathVariable String mbid){
+        return ResponseEntity.ok(userArtistTagService.getUserTagsByUserAndArtistMbid(user,mbid));
     }
 }

--- a/src/main/java/com/luciano/music_graph/dto/UserArtistDetail.java
+++ b/src/main/java/com/luciano/music_graph/dto/UserArtistDetail.java
@@ -1,0 +1,18 @@
+package com.luciano.music_graph.dto;
+
+import com.luciano.music_graph.dto.userTag.TagResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+public record UserArtistDetail(
+        UUID id,
+        String mbid,
+        String name,
+        String bio,
+        List<ArtistTagData> tags,
+        List<AlbumDetail> albums,
+        List<TagResponse>  userTags,
+        boolean followed
+) {
+}

--- a/src/main/java/com/luciano/music_graph/dto/userArtistTag/UserArtistTagResponse.java
+++ b/src/main/java/com/luciano/music_graph/dto/userArtistTag/UserArtistTagResponse.java
@@ -3,8 +3,7 @@ package com.luciano.music_graph.dto.userArtistTag;
 import java.util.UUID;
 
 public record UserArtistTagResponse(
-        String artistMbid,
-        UUID tagId,
-        String tagName
+        UUID id,
+        String name
 ) {
 }

--- a/src/main/java/com/luciano/music_graph/mapper/UserArtistMapper.java
+++ b/src/main/java/com/luciano/music_graph/mapper/UserArtistMapper.java
@@ -1,9 +1,8 @@
 package com.luciano.music_graph.mapper;
 
-import com.luciano.music_graph.dto.ArtistSearchData;
-import com.luciano.music_graph.dto.ShortArtistInfoDto;
-import com.luciano.music_graph.dto.UserArtistResponse;
+import com.luciano.music_graph.dto.*;
 import com.luciano.music_graph.dto.lastfm.LFArtist;
+import com.luciano.music_graph.dto.userTag.TagResponse;
 import com.luciano.music_graph.model.Artist;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -23,4 +22,6 @@ public interface UserArtistMapper {
     @Mapping(target = "id", source = "lfArtist.mbid")
     @Mapping(target = "followed", source = "followed")
     ArtistSearchData toArtistSearchData(LFArtist lfArtist, boolean followed);
+
+    UserArtistDetail toUserArtistDetail(ArtistDetail artistDetail, List<TagResponse> userTags, boolean followed);
 }

--- a/src/main/java/com/luciano/music_graph/mapper/UserArtistTagMapper.java
+++ b/src/main/java/com/luciano/music_graph/mapper/UserArtistTagMapper.java
@@ -24,9 +24,8 @@ public interface UserArtistTagMapper {
     @Mapping(target = "userTag", source = "userTag")
     UserArtistTag toEntity(User user, Artist artist, UserTag userTag);
 
-    @Mapping(target = "artistMbid", source = "userArtistTag.artist.mbid")
-    @Mapping(target = "tagId", source = "userArtistTag.userTag.id")
-    @Mapping(target = "tagName", source = "userArtistTag.userTag.name")
+    @Mapping(target = "id", source = "userArtistTag.userTag.id")
+    @Mapping(target = "name", source = "userArtistTag.userTag.name")
     UserArtistTagResponse toUserArtistTagResponse(UserArtistTag userArtistTag);
 
     TagResponse toTagResponse(UserTag userTag);
@@ -45,4 +44,6 @@ public interface UserArtistTagMapper {
                 tags.stream().map(this::toTagResponse).toList()
         );
     }
+
+    List<TagResponse> toTagResponse(List<UserTag> userTags);
 }

--- a/src/main/java/com/luciano/music_graph/repository/UserArtistTagRepository.java
+++ b/src/main/java/com/luciano/music_graph/repository/UserArtistTagRepository.java
@@ -1,6 +1,7 @@
 package com.luciano.music_graph.repository;
 
 import com.luciano.music_graph.model.Artist;
+import com.luciano.music_graph.model.User;
 import com.luciano.music_graph.model.UserArtistTag;
 import com.luciano.music_graph.model.UserTag;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -32,4 +33,11 @@ public interface UserArtistTagRepository extends JpaRepository<UserArtistTag, UU
         where uat.artist.mbid = :mbid
     """)
     List<UserTag> findByArtistMbid(String mbid);
+
+    @Query("""
+        select uat.userTag
+        from UserArtistTag as uat
+        where uat.artist.mbid = :mbid and uat.user = :user
+    """)
+    List<UserTag> findByAllByUserAndArtist(User user, String mbid);
 }

--- a/src/main/java/com/luciano/music_graph/service/UserArtistRelationService.java
+++ b/src/main/java/com/luciano/music_graph/service/UserArtistRelationService.java
@@ -39,6 +39,7 @@ public class UserArtistRelationService {
             Long sharedTags = (Long) row[1];
 
             // check cuál es el más chico.
+            // todo: deberia cambiar a mbid por mayor consistencia?
             if (artist.getId().toString().compareTo(relatedArtist.getId().toString()) < 0){
                 artistA = artist;
                 artistB = relatedArtist;

--- a/src/main/java/com/luciano/music_graph/service/UserArtistService.java
+++ b/src/main/java/com/luciano/music_graph/service/UserArtistService.java
@@ -5,6 +5,7 @@ import com.luciano.music_graph.dto.*;
 import com.luciano.music_graph.dto.graph.Node;
 import com.luciano.music_graph.dto.lastfm.LFSearchResponse;
 import com.luciano.music_graph.dto.lastfm.LFSimilarArtistResponse;
+import com.luciano.music_graph.dto.userTag.TagResponse;
 import com.luciano.music_graph.exception.ArtistNotFoundException;
 import com.luciano.music_graph.exception.UserArtistNotFoundException;
 import com.luciano.music_graph.mapper.UserArtistMapper;
@@ -31,7 +32,7 @@ public class UserArtistService {
     private final ApiArtistRelationService apiArtistRelationService;
     private final LastFmClient lastFmClient;
     private final UserArtistMapper mapper;
-
+    private final UserArtistTagService userArtistTagService;
 
     @Lazy
     private UserArtist saveUserArtist(User user, Artist artist){
@@ -157,5 +158,14 @@ public class UserArtistService {
         );
 
         return nodes;
+    }
+
+    public UserArtistDetail getArtist(User user, String mbid){
+
+        ArtistDetail artistDetail = artistService.getOrImport(mbid);
+        boolean followed = userArtistRepository.isFollowed(user, mbid).orElse(false);
+        List<TagResponse> userTags = userArtistTagService.getUserTagsByUserAndArtistMbid(user, mbid);
+
+        return mapper.toUserArtistDetail(artistDetail, userTags, followed);
     }
 }

--- a/src/main/java/com/luciano/music_graph/service/UserArtistTagService.java
+++ b/src/main/java/com/luciano/music_graph/service/UserArtistTagService.java
@@ -4,6 +4,7 @@ package com.luciano.music_graph.service;
 import com.luciano.music_graph.dto.userArtistTag.ArtistsByTagResponse;
 import com.luciano.music_graph.dto.userArtistTag.TagsByArtistResponse;
 import com.luciano.music_graph.dto.userArtistTag.UserArtistTagResponse;
+import com.luciano.music_graph.dto.userTag.TagResponse;
 import com.luciano.music_graph.exception.ArtistNotFoundException;
 import com.luciano.music_graph.exception.UserArtistTagNotFoundException;
 import com.luciano.music_graph.mapper.UserArtistTagMapper;
@@ -67,5 +68,11 @@ public class UserArtistTagService {
         List<UserTag> userTags = userArtistTagRepository.findByArtistMbid(mbid);
 
         return mapper.toTagsByArtist(artist, userTags);
+    }
+
+    public List<TagResponse> getUserTagsByUserAndArtistMbid(User user, String mbid){
+
+        List<UserTag> userTags = userArtistTagRepository.findByAllByUserAndArtist(user, mbid);
+        return mapper.toTagResponse(userTags);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,7 +14,7 @@ spring:
 
 jwt:
   access:
-    secret_key: "Y29udHJhc2XDsWEgZmFjaGVyaXRhY29udHJhc2XDsWEgZmFjaGVyaXRhY29udHJhc2XDsWEgZmFjaGVyaXRh"
+    secret_key: "dW5hY29udHJhc2VubmFzdXBlcnNlZ3VyYXlsb3N1ZmljaWVudGVtZW50ZWxhcmdhY29tb3BhcmFwb2RlcmhhY2VycXVlZWxlbmNyaXB0YW1pZW5kb2Z1bmNpb25l"
     expiration: 3600000        # 1 hora
   refresh:
     expiration: 604800000     # 7 dias

--- a/src/main/resources/db/migration/V14__add_enriched_and_source_in_artist.sql
+++ b/src/main/resources/db/migration/V14__add_enriched_and_source_in_artist.sql
@@ -1,3 +1,3 @@
 ALTER TABLE artist
-    ADD COLUMN source VARCHAR(12) NOT NULL,
-    ADD COLUMN enriched BOOLEAN NOT NULL;
+    ADD COLUMN source VARCHAR(12) ,
+    ADD COLUMN enriched BOOLEAN ;

--- a/src/main/resources/db/migration/V15__add_on_cascade_user_artist_tag.sql
+++ b/src/main/resources/db/migration/V15__add_on_cascade_user_artist_tag.sql
@@ -1,0 +1,8 @@
+ALTER TABLE user_artist_tags
+DROP CONSTRAINT user_artist_tags_user_tag_id_fkey;
+
+ALTER TABLE user_artist_tags
+    ADD CONSTRAINT user_artist_tags_user_tag_id_fkey
+        FOREIGN KEY (user_tag_id)
+            REFERENCES user_tags(id)
+            ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V6__create_api_artist_relations.sql
+++ b/src/main/resources/db/migration/V6__create_api_artist_relations.sql
@@ -7,6 +7,6 @@ create table api_artist_relations(
     primary key (id),
     foreign key (artist_a_id) references artist(id),
     foreign key (artist_b_id) references artist(id),
-    constraint chk_artist_order check ( artist_a_id < artist_b_id ),
+--     constraint chk_artist_order check ( artist_a_id < artist_b_id ),
     constraint uq_api_artist_relation unique( artist_a_id, artist_b_id )
 );


### PR DESCRIPTION
close #68 

## What
Refactor driven by frontend integration needs. Artists are now sourced from UserArtistService for richer user context, and user artist tag responses were enriched and finalized.

## Changes
- Update migrations: V6, V14 and add V15 for cascade on user artist tags
- Enrich `UserArtistTagResponse`, `UserArtistTagService`, `UserArtistTagMapper` and `UserArtistTagRepository`
- Add `UserArtistDetail` DTO
- Refactor `ArtistController`, `UserArtistMapper`, `UserArtistRelationService` and `UserArtistService` to source artists from `UserArtistService`
- Update dev and Docker configuration